### PR TITLE
Fix possible compilation error for variables expecting any kind of cache store

### DIFF
--- a/spec/entry_spec.cr
+++ b/spec/entry_spec.cr
@@ -1,0 +1,20 @@
+require "./spec_helper"
+
+describe Cache::Entry do
+  describe "#expired?" do
+    it "returns true if the entry is expired" do
+      entry = Cache::Entry.new("foobar", expires_in: -2.minutes)
+      entry.expired?.should be_true
+    end
+
+    it "returns false if the entry is not expired" do
+      entry = Cache::Entry.new("foobar", expires_in: 2.minutes)
+      entry.expired?.should be_false
+    end
+
+    it "returns false if the entry has no expiry" do
+      entry = Cache::Entry.new("foobar")
+      entry.expired?.should be_false
+    end
+  end
+end

--- a/src/cache/entry.cr
+++ b/src/cache/entry.cr
@@ -5,18 +5,22 @@ module Cache
   struct Entry(V)
     include YAML::Serializable
 
-    @expires_at : Time
+    @expires_at : Time?
 
     getter value
     getter expires_at
 
-    def initialize(@value : V, expires_in : Time::Span)
-      @expires_at = Time.utc + expires_in
+    def initialize(@value : V, expires_in : Time::Span? = nil)
+      @expires_at = Time.utc + expires_in if !expires_in.nil?
     end
 
     # Checks if the entry is expired.
     def expired?
-      @expires_at && @expires_at <= Time.utc
+      if !(expires_at = @expires_at).nil?
+        return expires_at <= Time.utc
+      end
+
+      false
     end
   end
 end

--- a/src/cache/store.cr
+++ b/src/cache/store.cr
@@ -10,6 +10,7 @@ module Cache
   # under the `/src/cache/stores` directory, e.g.
   # All implementations should support method , `write`, `read`, `fetch`, and `delete`.
   abstract struct Store(K, V)
+    @expires_in : Time::Span?
     @keys : Set(K) = Set(K).new
     @namespace : String? = nil
 


### PR DESCRIPTION
# Description

I encountered a possible compilation error with the `Cache::Store` class when defining variables accepting any kind of `Cache::Store(String, String)` object.

For example:

```crystal
require "cache"

class Test
  @cache_store : Cache::Store(String, String)? = nil
  
  property cache_store
end

test = Test.new
test.cache_store = Cache::MemoryStore(String, String).new(expires_in: 15.minutes)
test.cache_store.not_nil!.fetch("foo") { "bar" }
```

This snippet fails with the following compilation error:

```
Error: instantiating 'Cache::Store(String, String)+#fetch(String)'


In lib/cache/src/cache/store.cr:35:40

 35 | def fetch(key : K, *, expires_in = @expires_in, &block)
                                         ^----------
Error: can't infer the type of instance variable '@expires_in' of Cache::Store(String, String)

Could you add a type annotation like this

    struct Cache::Store(String, String)
      @expires_in : Type
    end

replacing `Type` with the expected type of `@expires_in`?
```

It seems that this is related to the use of the `@expires_in` instance variable in the `Cache::Store` abstract class: this instance variable is not defined by this class directly but is referenced nonetheless.

To fix this, I ensured that a _nilable_ `@expires_in` instance variable is defined in the `Cache::Store` abstract class. This also led me to modify the `Cache::Entry` struct so that its `@expires_at` instance is nilable as well (I imagine this makes sense given that some entries could not have expiry times).
