### PR TITLE
Store(K, V) → Store(V) where keys are always String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [...]
 
+* **breaking change** Simplified store interface: `Store(K, V)` → `Store(V)` where keys are always strings https://github.com/crystal-cache/cache/pull/44
 * Implement compression for `FileStore` https://github.com/crystal-cache/cache/pull/42
 
 ## 0.15.1

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ user.id # => 6539796
 
 ## Usage
 
-> **Note**: The cache API has been updated. Keys are now always strings, and the store interface uses a single type parameter `Store(V)` where `V` is the value type. The previous `Store(K, V)` interface has been removed.
+> **Note**: The cache API has been updated in version 1.0.0. Keys are now always strings, and the store interface uses a single type parameter `Store(V)` where `V` is the value type. The previous `Store(K, V)` interface has been removed.
 
 ### Available stores
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ All store implementations support:
 * `write`
 * `read`
 * `delete`
+* `exists?`
 * `clear`
 
 #### fetch
@@ -170,6 +171,21 @@ store.read("foo") # => "bar"
 
 store.clear
 store.read("foo") # => nil
+```
+
+#### exists?
+
+Checks if a key exists in the cache. Returns `true` if the key exists and has not expired, `false` otherwise.
+
+```crystal
+store = Cache::MemoryStore(String).new(12.hours)
+
+store.write("foo", "bar")
+store.exists?("foo") # => true
+store.exists?("baz") # => false
+
+store.delete("foo")
+store.exists?("foo") # => false
 ```
 
 ### Memory

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Caché
 
-A key/value store where pairs can expire after a specified interval. Keys are always strings, and values can be any serializable Crystal type.
-
 ![Crystal CI](https://github.com/crystal-cache/cache/workflows/Crystal%20CI/badge.svg)
 [![GitHub release](https://img.shields.io/github/release/crystal-cache/cache.svg)](https://github.com/crystal-cache/cache/releases)
 [![License](https://img.shields.io/github/license/crystal-cache/cache.svg)](https://github.com/crystal-cache/cache/blob/main/LICENSE)
+
+A key/value store where pairs can expire after a specified interval. Keys are always strings, and values can be any serializable Crystal type.
 
 ## Installation
 

--- a/spec/file_store_spec.cr
+++ b/spec/file_store_spec.cr
@@ -9,28 +9,21 @@ describe Cache do
     end
 
     it "initialize" do
-      store = Cache::FileStore(String, String).new(expires_in: 12.hours, cache_path: cache_path)
+      store = Cache::FileStore(String).new(expires_in: 12.hours, cache_path: cache_path)
 
-      store.should be_a(Cache::Store(String, String))
+      store.should be_a(Cache::Store(String))
       store.cache_path.should end_with("/spec/cache")
     end
 
     it "write to cache first time" do
-      store = Cache::FileStore(String, String).new(12.hours, cache_path: cache_path)
+      store = Cache::FileStore(String).new(12.hours, cache_path: cache_path)
 
       value = store.fetch("foo") { "bar" }
       value.should eq("bar")
     end
 
-    it "has keys" do
-      store = Cache::FileStore(String, String).new(12.hours, cache_path: cache_path)
-
-      store.fetch("foo") { "bar" }
-      store.keys.should eq(Set{"foo"})
-    end
-
     it "fetch from cache" do
-      store = Cache::FileStore(String, String).new(12.hours, cache_path: cache_path)
+      store = Cache::FileStore(String).new(12.hours, cache_path: cache_path)
 
       value = store.fetch("foo") { "bar" }
       value.should eq("bar")
@@ -40,7 +33,7 @@ describe Cache do
     end
 
     it "fetch from cache with generic types values" do
-      store = Cache::FileStore(String, String | Int32).new(expires_in: 12.hours, cache_path: cache_path)
+      store = Cache::FileStore(String | Int32).new(expires_in: 12.hours, cache_path: cache_path)
 
       value = store.fetch("string") { "bar" }
       value.should eq("bar")
@@ -50,7 +43,7 @@ describe Cache do
     end
 
     it "fetch from cache with false values" do
-      store = Cache::FileStore(String, String | Bool).new(expires_in: 12.hours, cache_path: cache_path)
+      store = Cache::FileStore(String | Bool).new(expires_in: 12.hours, cache_path: cache_path)
 
       value = store.fetch("foo") { false }
       value.should be_false
@@ -61,7 +54,7 @@ describe Cache do
 
     it "don't fetch from cache if expired" do
       freeze do |time|
-        store = Cache::FileStore(String, String).new(1.seconds, cache_path: cache_path)
+        store = Cache::FileStore(String).new(1.seconds, cache_path: cache_path)
 
         value = store.fetch("foo") { "bar" }
         value.should eq("bar")
@@ -75,7 +68,7 @@ describe Cache do
 
     it "fetch with expires_in from cache" do
       freeze do |time|
-        store = Cache::FileStore(String, String).new(1.seconds, cache_path: cache_path)
+        store = Cache::FileStore(String).new(1.seconds, cache_path: cache_path)
 
         value = store.fetch("foo", expires_in: 1.hours) { "bar" }
         value.should eq("bar")
@@ -89,7 +82,7 @@ describe Cache do
 
     it "don't fetch with expires_in from cache if expires" do
       freeze do |time|
-        store = Cache::FileStore(String, String).new(12.hours, cache_path: cache_path)
+        store = Cache::FileStore(String).new(12.hours, cache_path: cache_path)
 
         value = store.fetch("foo", expires_in: 1.seconds) { "bar" }
         value.should eq("bar")
@@ -102,7 +95,7 @@ describe Cache do
     end
 
     it "write" do
-      store = Cache::FileStore(String, String).new(12.hours, cache_path: cache_path)
+      store = Cache::FileStore(String).new(12.hours, cache_path: cache_path)
       store.write("foo", "bar", expires_in: 1.minute)
 
       value = store.fetch("foo") { "baz" }
@@ -110,7 +103,7 @@ describe Cache do
     end
 
     it "read" do
-      store = Cache::FileStore(String, String).new(12.hours, cache_path: cache_path)
+      store = Cache::FileStore(String).new(12.hours, cache_path: cache_path)
       store.write("foo", "bar")
 
       value = store.read("foo")
@@ -118,14 +111,14 @@ describe Cache do
     end
 
     it "read nil if key does not exists" do
-      store = Cache::FileStore(String, String).new(expires_in: 12.hours, cache_path: cache_path)
+      store = Cache::FileStore(String).new(expires_in: 12.hours, cache_path: cache_path)
 
       value = store.read("foo")
       value.should be_nil
     end
 
     it "fetch without block" do
-      store = Cache::FileStore(String, String).new(expires_in: 12.hours, cache_path: cache_path)
+      store = Cache::FileStore(String).new(expires_in: 12.hours, cache_path: cache_path)
       store.write("foo", "bar")
 
       value = store.fetch("foo")
@@ -134,13 +127,12 @@ describe Cache do
 
     it "set a custom expires_in value for one entry on write" do
       freeze do |time|
-        store = Cache::FileStore(String, String).new(12.hours, cache_path: cache_path)
+        store = Cache::FileStore(String).new(12.hours, cache_path: cache_path)
         store.write("foo", "bar", expires_in: 1.second)
 
         Timecop.travel(time + 2.seconds)
 
         File.exists?(File.join(cache_path, "foo")).should be_true
-        store.keys.should be_empty
 
         value = store.read("foo")
         value.should be_nil
@@ -150,7 +142,7 @@ describe Cache do
     end
 
     it "delete from cache" do
-      store = Cache::FileStore(String, String).new(12.hours, cache_path: cache_path)
+      store = Cache::FileStore(String).new(12.hours, cache_path: cache_path)
 
       value = store.fetch("foo") { "bar" }
       value.should eq("bar")
@@ -162,11 +154,10 @@ describe Cache do
       value = store.read("foo")
       value.should be_nil
       File.exists?(File.join(cache_path, "foo")).should be_false
-      store.keys.should be_empty
     end
 
     it "deletes all items from the cache" do
-      store = Cache::FileStore(String, String).new(12.hours, cache_path: cache_path)
+      store = Cache::FileStore(String).new(12.hours, cache_path: cache_path)
 
       value = store.fetch("foo") { "bar" }
       value.should eq("bar")
@@ -175,11 +166,10 @@ describe Cache do
       store.clear
 
       File.exists?(File.join(cache_path, "foo")).should be_false
-      store.keys.should be_empty
     end
 
     it "#exists?" do
-      store = Cache::FileStore(String, String).new(12.hours, cache_path: cache_path)
+      store = Cache::FileStore(String).new(12.hours, cache_path: cache_path)
 
       store.write("foo", "bar")
 
@@ -189,7 +179,7 @@ describe Cache do
 
     it "#exists? expires" do
       freeze do |time|
-        store = Cache::FileStore(String, String).new(1.second, cache_path: cache_path)
+        store = Cache::FileStore(String).new(1.second, cache_path: cache_path)
 
         store.write("foo", "bar")
 
@@ -200,7 +190,7 @@ describe Cache do
     end
 
     it "#increment" do
-      store = Cache::FileStore(String, Int32).new(12.hours, cache_path: cache_path)
+      store = Cache::FileStore(Int32).new(12.hours, cache_path: cache_path)
 
       store.write("num", 1)
       store.increment("num", 1)
@@ -211,7 +201,7 @@ describe Cache do
     end
 
     it "#decrement" do
-      store = Cache::FileStore(String, Int32).new(12.hours, cache_path: cache_path)
+      store = Cache::FileStore(Int32).new(12.hours, cache_path: cache_path)
 
       store.write("num", 2)
       store.decrement("num", 1)
@@ -225,7 +215,7 @@ describe Cache do
       [false, true].each do |compress|
         context "with compress #{compress}" do
           it "compresses string values" do
-            store = Cache::FileStore(String, String).new(expires_in: 12.hours, cache_path: cache_path, compress: compress)
+            store = Cache::FileStore(String).new(expires_in: 12.hours, cache_path: cache_path, compress: compress)
 
             value = store.fetch("foo") { "bar" }
             value.should eq("bar")
@@ -235,7 +225,7 @@ describe Cache do
           end
 
           it "does not compress non-string values" do
-            store = Cache::FileStore(String, Int32).new(expires_in: 12.hours, cache_path: cache_path, compress: compress)
+            store = Cache::FileStore(Int32).new(expires_in: 12.hours, cache_path: cache_path, compress: compress)
 
             value = store.fetch("foo") { 42 }
             value.should eq(42)
@@ -245,7 +235,7 @@ describe Cache do
           end
 
           it "handles large string compression" do
-            store = Cache::FileStore(String, String).new(expires_in: 12.hours, cache_path: cache_path, compress: compress)
+            store = Cache::FileStore(String).new(expires_in: 12.hours, cache_path: cache_path, compress: compress)
 
             large_string = "x" * 1000
             value = store.fetch("large") { large_string }

--- a/spec/log_spec.cr
+++ b/spec/log_spec.cr
@@ -6,7 +6,7 @@ describe Cache::Log do
       log_backend = Log::IOBackend.new(write)
       Log.builder.bind "cache.*", :debug, log_backend
 
-      store = Cache::MemoryStore(String, String).new(expires_in: 1.second)
+      store = Cache::MemoryStore(String).new(expires_in: 1.second)
 
       store.fetch("foo") { "bar" }
       store.delete("foo")

--- a/spec/memory_store_spec.cr
+++ b/spec/memory_store_spec.cr
@@ -3,43 +3,35 @@ require "./spec_helper"
 describe Cache do
   context Cache::MemoryStore do
     context "initialize" do
-      it "String as key" do
-        store = Cache::MemoryStore(String, String).new(expires_in: 12.hours)
+      it "String values" do
+        store = Cache::MemoryStore(String).new(expires_in: 12.hours)
 
-        store.should be_a(Cache::Store(String, String))
+        store.should be_a(Cache::Store(String))
       end
 
-      it "with union Int32 | String as key" do
-        store = Cache::MemoryStore(Int32 | String, String).new(expires_in: 12.hours)
+      it "Integer values" do
+        store = Cache::MemoryStore(Int32).new(expires_in: 12.hours)
 
-        store.should be_a(Cache::Store(Int32 | String, String))
+        store.should be_a(Cache::Store(Int32))
 
-        store.fetch("foo") { "bar" }
-        store.fetch(1) { "baz" }
-        store.keys.should eq(Set{"foo", 1})
-        store.read("foo").should eq("bar")
-        store.read(1).should eq("baz")
+        store.fetch("foo") { 42 }
+        store.fetch("bar") { 100 }
+        store.read("foo").should eq(42)
+        store.read("bar").should eq(100)
       end
     end
 
     [true, false].each do |compress|
       context "with compress #{compress}" do
         it "write to cache first time" do
-          store = Cache::MemoryStore(String, String).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(String).new(expires_in: 12.hours, compress: compress)
 
           value = store.fetch("foo") { "bar" }
           value.should eq("bar")
         end
 
-        it "has keys" do
-          store = Cache::MemoryStore(String, String).new(expires_in: 12.hours, compress: compress)
-
-          store.fetch("foo") { "bar" }
-          store.keys.should eq(Set{"foo"})
-        end
-
         it "fetch from cache" do
-          store = Cache::MemoryStore(String, String).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(String).new(expires_in: 12.hours, compress: compress)
 
           value = store.fetch("foo") { "bar" }
           value.should eq("bar")
@@ -49,7 +41,7 @@ describe Cache do
         end
 
         it "fetch from cache with generic types values" do
-          store = Cache::MemoryStore(String, String | Int32).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(String | Int32).new(expires_in: 12.hours, compress: compress)
 
           value = store.fetch("string") { "bar" }
           value.should eq("bar")
@@ -59,7 +51,7 @@ describe Cache do
         end
 
         it "fetch from cache with false values" do
-          store = Cache::MemoryStore(String, String | Bool).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(String | Bool).new(expires_in: 12.hours, compress: compress)
 
           value = store.fetch("foo") { false }
           value.should be_false
@@ -70,7 +62,7 @@ describe Cache do
 
         it "don't fetch from cache if expires" do
           freeze do |time|
-            store = Cache::MemoryStore(String, String).new(expires_in: 1.seconds, compress: compress)
+            store = Cache::MemoryStore(String).new(expires_in: 1.seconds, compress: compress)
 
             value = store.fetch("foo") { "bar" }
             value.should eq("bar")
@@ -84,7 +76,7 @@ describe Cache do
 
         it "fetch with expires_in from cache" do
           freeze do |time|
-            store = Cache::MemoryStore(String, String).new(expires_in: 1.seconds, compress: compress)
+            store = Cache::MemoryStore(String).new(expires_in: 1.seconds, compress: compress)
 
             value = store.fetch("foo", expires_in: 1.hours) { "bar" }
             value.should eq("bar")
@@ -98,7 +90,7 @@ describe Cache do
 
         it "don't fetch with expires_in from cache if expires" do
           freeze do |time|
-            store = Cache::MemoryStore(String, String).new(expires_in: 12.hours, compress: compress)
+            store = Cache::MemoryStore(String).new(expires_in: 12.hours, compress: compress)
 
             value = store.fetch("foo", expires_in: 1.seconds) { "bar" }
             value.should eq("bar")
@@ -111,7 +103,7 @@ describe Cache do
         end
 
         it "write" do
-          store = Cache::MemoryStore(String, String).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(String).new(expires_in: 12.hours, compress: compress)
           store.write("foo", "bar", expires_in: 1.minute)
 
           value = store.fetch("foo") { "baz" }
@@ -119,7 +111,7 @@ describe Cache do
         end
 
         it "read" do
-          store = Cache::MemoryStore(String, String).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(String).new(expires_in: 12.hours, compress: compress)
           store.write("foo", "bar")
 
           value = store.read("foo")
@@ -127,14 +119,14 @@ describe Cache do
         end
 
         it "read nil if key does not exists" do
-          store = Cache::MemoryStore(String, String).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(String).new(expires_in: 12.hours, compress: compress)
 
           value = store.read("foo")
           value.should be_nil
         end
 
         it "fetch without block" do
-          store = Cache::MemoryStore(String, String).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(String).new(expires_in: 12.hours, compress: compress)
           store.write("foo", "bar")
 
           value = store.fetch("foo")
@@ -143,7 +135,7 @@ describe Cache do
 
         it "set a custom expires_in value for one entry on write" do
           freeze do |time|
-            store = Cache::MemoryStore(String, String).new(expires_in: 12.hours, compress: compress)
+            store = Cache::MemoryStore(String).new(expires_in: 12.hours, compress: compress)
             store.write("foo", "bar", expires_in: 1.second)
 
             Timecop.travel(time + 2.seconds)
@@ -154,7 +146,7 @@ describe Cache do
         end
 
         it "delete from cache" do
-          store = Cache::MemoryStore(String, String).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(String).new(expires_in: 12.hours, compress: compress)
 
           value = store.fetch("foo") { "bar" }
           value.should eq("bar")
@@ -164,11 +156,10 @@ describe Cache do
 
           value = store.read("foo")
           value.should be_nil
-          store.keys.should eq(Set(String).new)
         end
 
         it "deletes all items from the cache" do
-          store = Cache::MemoryStore(String, String).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(String).new(expires_in: 12.hours, compress: compress)
 
           value = store.fetch("foo") { "bar" }
           value.should eq("bar")
@@ -177,12 +168,10 @@ describe Cache do
 
           value = store.read("foo")
           value.should be_nil
-          store.keys.should eq(Set(String).new)
-          store.keys.should be_empty
         end
 
         it "#exists?" do
-          store = Cache::MemoryStore(String, String).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(String).new(expires_in: 12.hours, compress: compress)
 
           store.write("foo", "bar")
 
@@ -192,7 +181,7 @@ describe Cache do
 
         it "#exists? expires" do
           freeze do |time|
-            store = Cache::MemoryStore(String, String).new(expires_in: 1.second, compress: compress)
+            store = Cache::MemoryStore(String).new(expires_in: 1.second, compress: compress)
 
             store.write("foo", "bar")
 
@@ -203,7 +192,7 @@ describe Cache do
         end
 
         it "#increment" do
-          store = Cache::MemoryStore(String, Int32).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(Int32).new(expires_in: 12.hours, compress: compress)
 
           store.write("num", 1)
           store.increment("num", 1)
@@ -214,7 +203,7 @@ describe Cache do
         end
 
         it "#decrement" do
-          store = Cache::MemoryStore(String, Int32).new(expires_in: 12.hours, compress: compress)
+          store = Cache::MemoryStore(Int32).new(expires_in: 12.hours, compress: compress)
 
           store.write("num", 2)
           store.decrement("num", 1)
@@ -230,7 +219,7 @@ describe Cache do
       [true, false].each do |compress|
         context "with compress #{compress}" do
           it "fetch from cache" do
-            store = Cache::MemoryStore(String, Hash(String, String | Int32))
+            store = Cache::MemoryStore(Hash(String, String | Int32))
               .new(expires_in: 30.seconds, compress: compress)
 
             data = {
@@ -251,7 +240,7 @@ describe Cache do
           end
 
           it "write and read" do
-            store = Cache::MemoryStore(String, Hash(String, String | Int32))
+            store = Cache::MemoryStore(Hash(String, String | Int32))
               .new(expires_in: 30.seconds, compress: compress)
 
             data = {
@@ -263,21 +252,6 @@ describe Cache do
 
             result = store.read("data_key")
             result.should eq(data)
-          end
-        end
-
-        it "keys returns only non-expired keys" do
-          freeze do |time|
-            store = Cache::MemoryStore(String, String).new(expires_in: 1.second, compress: compress)
-
-            store.write("foo", "bar")
-            store.write("baz", "qux", expires_in: 5.seconds)
-
-            store.keys.should eq(Set{"foo", "baz"})
-
-            Timecop.travel(time + 2.seconds)
-
-            store.keys.should eq(Set{"baz"})
           end
         end
       end

--- a/spec/null_store_spec.cr
+++ b/spec/null_store_spec.cr
@@ -3,34 +3,27 @@ require "./spec_helper"
 describe Cache do
   context Cache::NullStore do
     it "initialize" do
-      store = Cache::NullStore(String, String).new(expires_in: 12.hours)
+      store = Cache::NullStore(String).new(expires_in: 12.hours)
 
-      store.should be_a(Cache::Store(String, String))
+      store.should be_a(Cache::Store(String))
     end
 
     it "fetch" do
-      store = Cache::NullStore(String, String).new(12.hours)
+      store = Cache::NullStore(String).new(12.hours)
 
       value = store.fetch("foo") { "bar" }
       value.should eq("bar")
     end
 
     it "fetch with expires_in" do
-      store = Cache::NullStore(String, String).new(12.hours)
+      store = Cache::NullStore(String).new(12.hours)
 
       value = store.fetch("foo", expires_in: 3.hours) { "bar" }
       value.should eq("bar")
     end
 
-    it "has keys" do
-      store = Cache::NullStore(String, String).new(12.hours)
-
-      store.fetch("foo") { "bar" }
-      store.keys.should eq(Set{"foo"})
-    end
-
     it "delete from cache" do
-      store = Cache::NullStore(String, String).new(12.hours)
+      store = Cache::NullStore(String).new(12.hours)
 
       value = store.fetch("foo") { "bar" }
       value.should eq("bar")
@@ -40,18 +33,15 @@ describe Cache do
 
       value = store.read("foo")
       value.should be_nil
-      store.keys.should eq(Set(String).new)
     end
 
     it "deletes all items from the cache" do
-      store = Cache::NullStore(String, String).new(12.hours)
+      store = Cache::NullStore(String).new(12.hours)
 
       value = store.fetch("foo") { "bar" }
       value.should eq("bar")
 
       store.clear
-
-      store.keys.should be_empty
     end
   end
 end

--- a/src/cache/entry.cr
+++ b/src/cache/entry.cr
@@ -7,7 +7,7 @@ module Cache
 
     @expires_at : Time
 
-    getter value
+    getter value : V
     getter expires_at
 
     def initialize(@value : V, expires_in : Time::Span = Time::Span::ZERO)

--- a/src/cache/stores/null_store.cr
+++ b/src/cache/stores/null_store.cr
@@ -4,24 +4,25 @@ module Cache
   # A cache store implementation which doesn't actually store anything. Useful in
   # development and test environments where you don't want caching turned on but
   # need to go through the caching interface.
-  struct NullStore(K, V) < Store(K, V)
+  struct NullStore(V) < Store(V)
     def initialize(@expires_in : Time::Span)
     end
 
-    private def write_impl(key : K, value : V, *, expires_in = @expires_in)
+    private def write_impl(key : String, value : V, *, expires_in = @expires_in)
       @keys << key
     end
 
-    private def read_impl(key : K)
+    private def read_impl(key : String)
+      nil
     end
 
-    private def delete_impl(key : K) : Bool
+    private def delete_impl(key : String) : Bool
       @keys.delete(key)
 
       true
     end
 
-    private def exists_impl(key : K) : Bool
+    private def exists_impl(key : String) : Bool
       @keys.includes?(key)
     end
 


### PR DESCRIPTION
Update implementations:

* [x] - [redis_cache_store](https://github.com/crystal-cache/redis_cache_store) - https://github.com/crystal-cache/redis_cache_store/pull/11
* [x] - [redis_legacy_cache_store](https://github.com/crystal-cache/redis_legacy_cache_store) - https://github.com/crystal-cache/redis_legacy_cache_store/pull/2
* [x] - [mem_cache_store](https://github.com/crystal-cache/mem_cache_store) - https://github.com/crystal-cache/mem_cache_store/pull/3
* [x] - [postgres_cache_store](https://github.com/crystal-cache/postgres_cache_store) - https://github.com/crystal-cache/postgres_cache_store/pull/6
* [x] - [mysql_cache_store](https://github.com/crystal-cache/mysql_cache_store) - https://github.com/crystal-cache/mysql_cache_store/pull/6